### PR TITLE
Update lab 02_7 to use pre-created chroma_inputs.jsonl fallback

### DIFF
--- a/01_materials/labs/02_7_vectordb_docker.ipynb
+++ b/01_materials/labs/02_7_vectordb_docker.ipynb
@@ -42,7 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "batch_description = 'Pitchfork reviews content embeddings 2025-10-18 12:17:17'"
+    "batch_description = 'Pitchfork reviews content embeddings (jcalderon_20260212) 2026-04-21 18:26:19'"
    ]
   },
   {
@@ -53,6 +53,7 @@
    "outputs": [],
    "source": [
     "from openai import OpenAI\n",
+    "import os\n",
     "\n",
     "client = OpenAI(base_url='https://k7uffyg03f.execute-api.us-east-1.amazonaws.com/prod/openai/v1', \n",
     "                default_headers={\"x-api-key\": os.getenv('API_GATEWAY_KEY')})\n",
@@ -108,10 +109,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = client.files.content(batch_complete[0]['output_file_id'])\n",
-    "text_response = response.text\n",
-    "lines = text_response.split('\\n')\n",
-    "print(lines[0])\n"
+    "# response = client.files.content(batch_complete[0]['output_file_id'])\n",
+    "# text_response = response.text\n",
+    "# lines = text_response.split('\\n')\n",
+    "# print(lines[0])\n",
+    "\n",
+    "print(batch_complete[0].get(\"status\"))\n",
+    "print(batch_complete[0].get(\"output_file_id\"))\n",
+    "print(batch_complete[0].get(\"error_file_id\"))"
    ]
   },
   {
@@ -129,19 +134,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json \n",
+    "# import json \n",
     "\n",
-    "def get_text_and_embeddings(batch):\n",
-    "    embedding_lines =  get_content_from_file(batch, 'output_file_id')\n",
-    "    text_lines = get_content_from_file(batch, 'input_file_id')\n",
-    "    return embedding_lines, text_lines\n",
+    "# def get_text_and_embeddings(batch):\n",
+    "#     embedding_lines =  get_content_from_file(batch, 'output_file_id')\n",
+    "#     text_lines = get_content_from_file(batch, 'input_file_id')\n",
+    "#     return embedding_lines, text_lines\n",
     "\n",
-    "def get_content_from_file(batch, key):\n",
-    "    file = client.files.content(batch[key])\n",
-    "    text = file.text\n",
-    "    lines = text.split('\\n')\n",
-    "    content_lines = [json.loads(line) for line in lines if line.strip()]\n",
-    "    return content_lines\n"
+    "# def get_content_from_file(batch, key):\n",
+    "#     file = client.files.content(batch[key])\n",
+    "#     text = file.text\n",
+    "#     lines = text.split('\\n')\n",
+    "#     content_lines = [json.loads(line) for line in lines if line.strip()]\n",
+    "#     return content_lines\n"
    ]
   },
   {
@@ -164,19 +169,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def create_chroma_inputs(embedding_lines, text_lines):\n",
-    "    chroma_inputs = []\n",
-    "    text_dict = {item['custom_id']: item['body']['input'] for item in text_lines}\n",
-    "    for embed_item in embedding_lines:\n",
-    "        custom_id = embed_item['custom_id']\n",
-    "        text = text_dict.get(custom_id, \"\")\n",
-    "        chroma_input = {\n",
-    "            'id': embed_item['custom_id'],\n",
-    "            'embedding': embed_item['response']['body']['data'][0]['embedding'],\n",
-    "            'text': text\n",
-    "        }\n",
-    "        chroma_inputs.append(chroma_input)\n",
-    "    return chroma_inputs"
+    "# def create_chroma_inputs(embedding_lines, text_lines):\n",
+    "#     chroma_inputs = []\n",
+    "#     text_dict = {item['custom_id']: item['body']['input'] for item in text_lines}\n",
+    "#     for embed_item in embedding_lines:\n",
+    "#         custom_id = embed_item['custom_id']\n",
+    "#         text = text_dict.get(custom_id, \"\")\n",
+    "#         chroma_input = {\n",
+    "#             'id': embed_item['custom_id'],\n",
+    "#             'embedding': embed_item['response']['body']['data'][0]['embedding'],\n",
+    "#             'text': text\n",
+    "#         }\n",
+    "#         chroma_inputs.append(chroma_input)\n",
+    "#     return chroma_inputs"
    ]
   },
   {
@@ -194,19 +199,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tqdm import tqdm\n",
+    "# from tqdm import tqdm\n",
     "\n",
-    "def process_batch_for_chromadb(batch):\n",
-    "    embedding_lines, text_lines = get_text_and_embeddings(batch)\n",
-    "    chroma_inputs = create_chroma_inputs(embedding_lines, text_lines)\n",
-    "    return chroma_inputs\n",
+    "# def process_batch_for_chromadb(batch):\n",
+    "#     embedding_lines, text_lines = get_text_and_embeddings(batch)\n",
+    "#     chroma_inputs = create_chroma_inputs(embedding_lines, text_lines)\n",
+    "#     return chroma_inputs\n",
     "\n",
-    "def process_batches_for_chromadb(batches):\n",
-    "    all_chroma_inputs = []\n",
-    "    for batch in tqdm(batches, desc=\"Processing batches\"):\n",
-    "        chroma_inputs = process_batch_for_chromadb(batch)\n",
-    "        all_chroma_inputs.extend(chroma_inputs)\n",
-    "    return all_chroma_inputs"
+    "# def process_batches_for_chromadb(batches):\n",
+    "#     all_chroma_inputs = []\n",
+    "#     for batch in tqdm(batches, desc=\"Processing batches\"):\n",
+    "#         chroma_inputs = process_batch_for_chromadb(batch)\n",
+    "#         all_chroma_inputs.extend(chroma_inputs)\n",
+    "#     return all_chroma_inputs"
    ]
   },
   {
@@ -214,6 +219,9 @@
    "id": "00a6c05b",
    "metadata": {},
    "source": [
+    "Download the `chroma_inputs.jsonl` file from the source provided by the instructional team and place it into:\n",
+    "`05_src/documents/`\n",
+    "\n",
     "Now, we can create our input dictionaries."
    ]
   },
@@ -224,7 +232,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chroma_inputs = process_batches_for_chromadb(batch_complete)"
+    "#chroma_inputs = process_batches_for_chromadb(batch_complete)\n",
+    "import json\n",
+    "\n",
+    "chroma_inputs = []\n",
+    "\n",
+    "with open(r\"../../05_src/documents/chroma_inputs.jsonl\", \"r\", encoding=\"utf-8\") as f:\n",
+    "    for line in f:\n",
+    "        chroma_inputs.append(json.loads(line))"
    ]
   },
   {
@@ -298,6 +313,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from tqdm import tqdm\n",
     "vector_db_client_url:str=\"http://localhost:8000\"\n",
     "load_embeddings_to_db(chroma_inputs=chroma_inputs,\n",
     "                      collection_name=\"pitchfork_reviews\",\n",
@@ -420,11 +436,29 @@
    "outputs": [],
    "source": [
     "chroma = chromadb.HttpClient(host=vector_db_client_url)\n",
-    "collection = chroma.get_collection(name=\"pitchfork_reviews\", \n",
-    "                                   embedding_function=OpenAIEmbeddingFunction(\n",
-    "                                       api_key = os.getenv(\"OPENAI_API_KEY\"),\n",
-    "                                       model_name=\"text-embedding-3-small\")\n",
-    "                                   )\n"
+    "# collection = chroma.get_collection(name=\"pitchfork_reviews\", \n",
+    "#                                    embedding_function=OpenAIEmbeddingFunction(\n",
+    "#                                        api_key = os.getenv(\"OPENAI_API_KEY\"),\n",
+    "#                                        model_name=\"text-embedding-3-small\")\n",
+    "#                                    )\n",
+    "\n",
+    "from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction\n",
+    "import os\n",
+    "\n",
+    "embedding_function = OpenAIEmbeddingFunction(\n",
+    "    api_key=\"any value\",\n",
+    "    api_base=\"https://k7uffyg03f.execute-api.us-east-1.amazonaws.com/prod/openai/v1\",\n",
+    "    api_type=\"openai\",\n",
+    "    model_name=\"text-embedding-3-small\",\n",
+    "    default_headers={\n",
+    "        \"x-api-key\": os.getenv(\"API_GATEWAY_KEY\")\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "collection = chroma.get_collection(\n",
+    "    name=\"pitchfork_reviews\",\n",
+    "    embedding_function=embedding_function\n",
+    ")"
    ]
   },
   {
@@ -533,7 +567,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "deploying-ai-env (3.12.7)",
+   "display_name": "deploying-ai-env (3.11.13)",
    "language": "python",
    "name": "python3"
   },
@@ -547,7 +581,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
SUMMARY:
During the last DAI cohorts, we had repeated issues with:
`response = client.files.content(batch_complete[0]['output_file_id'])`
The content() endpoint on the API gateway was returning 502 errors. It prevented us from pulling the content from batch_complete.

CHANGES:
- skipped dependency on the content endpoint
- used the pre-created `chroma_inputs.jsonl` file as a fallback
- loaded embeddings directly from the jsonl file into ChromaDB running in Docker
- kept the remaining vector database workflow unchanged

REASON:
This allows participants to continue the ChromaDB and semantic search lab even when the gateway content endpoint is unavailable.

RESULT:
After loading the pre-created embeddings into Chroma, the rest of the lab works smoothly without blocking students.

TESTED:
Re-ran the full lab in a freshly cloned UofT-DSI/deploying-ai repository using only needed dependencies provided in this and related labs. The workflow completed successfully using the chroma_inputs.jsonl fallback and ChromaDB in Docker.